### PR TITLE
Move fetching logic to websocket listener

### DIFF
--- a/webapp/src/header_icon.tsx
+++ b/webapp/src/header_icon.tsx
@@ -6,7 +6,7 @@ import {GlobalState} from 'mattermost-redux/types/store';
 import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/common';
 
 import {fetchNote} from 'client';
-import {setNoteValue} from 'redux_connectors';
+import {makeSelectNoteValue} from 'redux_connectors';
 
 interface HeaderIconProps {
     active?: boolean;
@@ -20,18 +20,9 @@ const HeaderIconContainer = styled.div<HeaderIconProps>`
 const HeaderIcon:FC = () => {
     const dispatch = useDispatch();
     const currentChannelId = useSelector<GlobalState, string>(getCurrentChannelId);
-    const [hasNote, setHasNote] = useState(false);
+    const note = useSelector<GlobalState, string>(makeSelectNoteValue(currentChannelId));
 
-    useEffect(() => {
-        const doFetch = async () => {
-            const fetchedNote = await fetchNote(currentChannelId);
-            setHasNote(fetchedNote !== '');
-            dispatch(setNoteValue(currentChannelId, fetchedNote));
-        };
-        doFetch();
-    }, [currentChannelId, dispatch]);
-
-    if (hasNote) {
+    if (note) {
         return (
             <HeaderIconContainer
                 active={true}

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -1,3 +1,4 @@
+import WebsocketEvents from 'mattermost-redux/constants/websocket';
 import {GlobalState} from 'mattermost-redux/types/store';
 
 import React from 'react';
@@ -8,7 +9,7 @@ import {PluginRegistry} from 'mattermost-webapp/plugins/registry';
 
 import NoteRHS from 'note_rhs';
 import HeaderIcon from 'header_icon';
-import {handleWebsocketNoteUpdate} from 'websocket';
+import {handleWebsocketNoteUpdate, handleWebsocketChannelViewed} from 'websocket';
 
 import manifest from './manifest';
 import {reducer} from './redux_connectors';
@@ -25,6 +26,7 @@ export default class Plugin {
 
         const channelNoteUpateEvent = `custom_${manifest.id}_channel_note_update`;
         registry.registerWebSocketEventHandler(channelNoteUpateEvent, handleWebsocketNoteUpdate(store.getState, store.dispatch));
+        registry.registerWebSocketEventHandler(WebsocketEvents.CHANNEL_VIEWED, handleWebsocketChannelViewed(store.getState, store.dispatch))
     }
 }
 

--- a/webapp/src/websocket.tsx
+++ b/webapp/src/websocket.tsx
@@ -3,10 +3,19 @@ import {Dispatch} from 'redux';
 import {GetStateFunc} from 'mattermost-redux/types/actions';
 import {WebSocketMessage} from 'mattermost-redux/types/websocket';
 
+import {fetchNote} from 'client';
 import {setNoteValue} from 'redux_connectors';
 
 export function handleWebsocketNoteUpdate(_: GetStateFunc, dispatch: Dispatch) {
     return async (msg: WebSocketMessage<{note: string}>) => {
         dispatch(setNoteValue(msg.broadcast.channel_id, msg.data.note));
+    };
+}
+
+export function handleWebsocketChannelViewed(_: GetStateFunc, dispatch: Dispatch) {
+    return async (msg: WebSocketMessage<{channel_id: string}>) => {
+        const currentChannelId = msg.data.channel_id;
+        const fetchedNote = await fetchNote(currentChannelId);
+        dispatch(setNoteValue(currentChannelId, fetchedNote));
     };
 }


### PR DESCRIPTION
This fixes the error found by @ in #4. The channel header icon contained the logic for fetching the notes for each channel, so when we use the App Bar icon (so the channel header icon is no longer mounted) that logic is never executed.

To solve this, I added a listener for the `CHANNEL_VIEWED` websocket event, so that when the user switches channel, the notes for that channel are fetched.

With this change, the old logic of the channel header icon changing its colour whenever the current channel has notes still works, and the bug found in #4 when the App Bar icon is shown is solved.